### PR TITLE
P3385: support equality operator for atrributes reflection

### DIFF
--- a/clang/lib/AST/APValue.cpp
+++ b/clang/lib/AST/APValue.cpp
@@ -548,9 +548,25 @@ static void profileReflection(llvm::FoldingSetNodeID &ID, APValue V) {
   case ReflectionKind::Namespace:
   case ReflectionKind::BaseSpecifier:
   case ReflectionKind::Annotation:
-  case ReflectionKind::Attribute:
     ID.AddPointer(V.getOpaqueReflectionData());
     return;
+  case ReflectionKind::Attribute: {
+    ParsedAttr* attr = V.getReflectedAttribute();
+    ID.AddString(attr->getAttrName()->getName());
+    if(attr->getNumArgs() > 0)
+    {
+        auto *Arg0 = attr->getArgAsExpr(0);
+        StringLiteral *Literal =
+          dyn_cast<StringLiteral>(Arg0->IgnoreParenCasts());
+        if(Literal) {
+          StringRef String = Literal->getString();
+          ID.AddInteger(String.size());
+          ID.AddString(String.data());
+        }
+    }
+
+    return;
+  }
   case ReflectionKind::DataMemberSpec: {
     TagDataMemberSpec *TDMS = V.getReflectedDataMemberSpec();
     TDMS->Ty.Profile(ID);

--- a/clang/test/Reflection/info-equality.cpp
+++ b/clang/test/Reflection/info-equality.cpp
@@ -140,6 +140,13 @@ static_assert(^^:: != ^^::myns);
 static_assert(^^::myns != ^^NsAlias);
 static_assert(^^::myns != ^^::myns::inner);
 
+// Check equality of attributes
+static_assert(^^[[nodiscard]] == ^^[[nodiscard]]);
+static_assert(^^[[nodiscard("test")]] != ^^[[nodiscard]]);
+static_assert(^^[[nodiscard("test")]] == ^^[[nodiscard("test")]]);
+static_assert(^^[[nodiscard("test")]] != ^^[[nodiscard("another test")]]);
+static_assert(^^[[nodiscard]] != ^^[[deprecated]]);
+
 constexpr int i = 42;
 constexpr auto i_refl = ^^i;
 constexpr auto i_refl_copy = i_refl;


### PR DESCRIPTION
Change the way we profile attribute 

- First, we add the attribute token string value 
- Add num of arg if it has, also string value and string size.