### PR TITLE
Return null reflection for non-reflectable attributes

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -3256,6 +3256,8 @@ def err_cannot_expand_over_type : Error<
 // P3385
 def p3385_sema_trace_execution_checkpoint : Warning<
   "(p3385-Sema) trace_execution_checkpoint %0">;
+def p3385_warn_unsupported_attribute : Warning<
+  "reflecting over '%0' attribute is not supported">;
 
 // C++11 char16_t/char32_t
 def warn_cxx98_compat_unicode_type : Warning<

--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -1716,14 +1716,14 @@ bool DiagnoseReflectionKind(DiagFn Diagnoser, SourceRange Range,
 
 llvm::SmallVector<const Attr*, 8> static collectUniqueCxx11Attrs(const Decl *D) {
   llvm::SmallVector<const Attr*, 8> Result;
-  // We ll persist a representation of the attribute != kind otherwise
+  // We ll persist a representation of the attribute with the scope otherwise
   // we would count [[clang::warn_unused_result]] and [[nodiscard]] as
-  // the same attribute which we do not want...
+  // the same attribute
   llvm::SmallSet<std::string, 8> SeenKinds;
 
   for (const Decl *RD : D->redecls()) {
     for (const Attr *A : RD->getAttrs()) {
-      if (!A->isCXX11Attribute()) {
+      if (!isAttributeWithReflectableVariant(A->getParsedKind())) {
         continue;
       }
       std::string S;

--- a/clang/lib/Sema/SemaReflect.cpp
+++ b/clang/lib/Sema/SemaReflect.cpp
@@ -18,6 +18,7 @@
 #include "clang/AST/DeclBase.h"
 #include "clang/AST/MetaActions.h"
 #include "clang/AST/Metafunction.h"
+#include "clang/AST/Reflection.h"
 #include "clang/Basic/DiagnosticSema.h"
 #include "clang/Sema/EnterExpressionEvaluationContext.h"
 #include "clang/Sema/Lookup.h"
@@ -1336,9 +1337,15 @@ ExprResult Sema::BuildCXXReflectExpr(SourceLocation OperatorLoc,
 
 ExprResult Sema::BuildCXXReflectExpr(SourceLocation OperatorLoc,
                                      ParsedAttr *A) {
+  bool isReflectable = isAttributeWithReflectableVariant(A->getParsedKind());
+  if (!isReflectable) {
+    Diag(A->getLoc(), diag::p3385_warn_unsupported_attribute)
+        << A->getAttrName()->getName();
+  }
   return CXXReflectExpr::Create(
       Context, OperatorLoc, A->getRange(),
-      APValue{ReflectionKind::Attribute, static_cast<void *>(A)});
+      APValue{isReflectable ? ReflectionKind::Attribute : ReflectionKind::Null,
+              static_cast<void *>(isReflectable ? A : nullptr)});
 }
 
 ExprResult Sema::BuildCXXMetafunctionExpr(

--- a/clang/utils/TableGen/ClangAttrEmitter.cpp
+++ b/clang/utils/TableGen/ClangAttrEmitter.cpp
@@ -2581,7 +2581,7 @@ static bool isVariadicStringLiteralArgument(const Record *Arg) {
   return ArgKind == "VariadicStringArgument";
 }
 
-// An attribute is reflectable (for now) if
+// An (family-of-variant) attribute is reflectable if
 // - it admits at least one CXX11 representation, and
 // - it has no arguments or all its arguments are of any of the types: string, bool, int
 // - it does not set 'EscapeReflection' to true
@@ -2598,10 +2598,11 @@ static bool isReflectableAttr(const Record* R) {
     return false;
   }
   bool hasStandardRepresentation = false;
-  for (const auto &Spelling : R->getValueAsListOfDefs("Spellings")) {
-    StringRef Variety = Spelling->getValueAsString("Variety");
-    StringRef Name = Spelling->getValueAsString("Name");
-    if (!Name.empty() && (Variety == "GCC" || Variety == "Clang" || Variety == "ClangGCC")) {
+  for (const auto &spelling : R->getValueAsListOfDefs("Spellings")) {
+    StringRef variety = spelling->getValueAsString("Variety");
+    // All those CXX11 are implied
+    if (!variety.empty() && (variety == "CXX11" || variety == "GCC" ||
+                             variety == "Clang" || variety == "ClangGCC")) {
       hasStandardRepresentation = true;
       break;
     }

--- a/libcxx/test/std/experimental/reflection/p3385-attributes.pass.cpp
+++ b/libcxx/test/std/experimental/reflection/p3385-attributes.pass.cpp
@@ -105,6 +105,14 @@ consteval bool testVendorSpecific() {
   return true;
 }
 
+consteval bool testUnsupported() {
+  static_assert(!std::meta::is_attribute(^^[[assume(true)]]));
+  static_assert(!std::meta::is_attribute(^^[[clang::assume(true)]]));
+  static_assert(!std::meta::is_attribute(^^[[my::stuff("anything")]]));
+  static_assert(^^[[assume(true)]] == std::meta::info());
+  return true;
+}
+
 int main() {
   static_assert(testIsAttribute(), "IsAttribute");
   static_assert(testHasIdentifier(), "HasIdentifier");
@@ -114,3 +122,4 @@ int main() {
   static_assert(testComparison() ,"Comparison");
   static_assert(testVendorSpecific() ,"VendorSpecific");
 }
+

--- a/libcxx/test/std/experimental/reflection/p3385-attributes.pass.cpp
+++ b/libcxx/test/std/experimental/reflection/p3385-attributes.pass.cpp
@@ -18,11 +18,12 @@
 // [reflection]
 #include <experimental/meta>
 
-// Note that 'Foo' mix standard and vendor namespaced
+// Note that 'Foo' mix standard and vendor namespaced, supported and unsupported
 struct [[nodiscard("std variant"), deprecated("dont use me")]]
-[[clang::warn_unused_result("clang variant")]] Foo {};
+[[clang::warn_unused_result("clang variant")]]
+[[clang::availability(macos,introduced=10.4,deprecated=10.6,obsoleted=10.7)]] Foo {};
 
-// This is vendor specific, does not exist in the standard
+// This is vendor specific & does not exist in the standard
 [[gnu::constructor(200)]] void gnuConstructor(void);
 
 // Some samples of vendor and standard attributes
@@ -72,6 +73,7 @@ consteval bool testAttributesOfType() {
       || i == ^^[[clang::warn_unused_result("clang variant")]];
   };
 
+  // This should not return the unsupported 'availability'
   static_assert(std::meta::attributes_of(^^Foo).size() == 3);
   
   constexpr auto att0 = std::meta::attributes_of(^^Foo)[0];
@@ -121,5 +123,6 @@ int main() {
   static_assert(testAttributesOfType() ,"AttributesOfType");
   static_assert(testComparison() ,"Comparison");
   static_assert(testVendorSpecific() ,"VendorSpecific");
+  static_assert(testUnsupported() ,"Unsupported");
 }
 


### PR DESCRIPTION
Reflecting over non supported attributes return null reflection