### PR TITLE
Pass filter on namespace and ID to attributes_of

### DIFF
--- a/clang/include/clang/Basic/AttributeCommonInfo.h
+++ b/clang/include/clang/Basic/AttributeCommonInfo.h
@@ -211,6 +211,7 @@ public:
   bool isDeclspecAttribute() const { return SyntaxUsed == AS_Declspec; }
   bool isMicrosoftAttribute() const { return SyntaxUsed == AS_Microsoft; }
 
+  bool isMsvcScope() const;
   bool isGNUScope() const;
   bool isClangScope() const;
 

--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -692,7 +692,26 @@ static bool get_ith_attribute_of(APValue &Result, ASTContext &C,
                                  DiagFn Diagnoser, bool AllowInjection,
                                  QualType ResultTy, SourceRange Range,
                                  ArrayRef<Expr *> Args, Decl *ContainingDecl);
-
+static bool is_unscoped_attribute(APValue &Result, ASTContext &C,
+                                  MetaActions &Meta, EvalFn Evaluator,
+                                  DiagFn Diagnoser, bool AllowInjection,
+                                  QualType ResultTy, SourceRange Range,
+                                  ArrayRef<Expr *> Args, Decl *ContainingDecl);
+static bool is_clang_attribute(APValue &Result, ASTContext &C,
+                               MetaActions &Meta, EvalFn Evaluator,
+                               DiagFn Diagnoser, bool AllowInjection,
+                               QualType ResultTy, SourceRange Range,
+                               ArrayRef<Expr *> Args, Decl *ContainingDecl);
+static bool is_gcc_attribute(APValue &Result, ASTContext &C,
+                             MetaActions &Meta, EvalFn Evaluator,
+                             DiagFn Diagnoser, bool AllowInjection,
+                             QualType ResultTy, SourceRange Range,
+                             ArrayRef<Expr *> Args, Decl *ContainingDecl);
+static bool is_msvc_attribute(APValue &Result, ASTContext &C,
+                              MetaActions &Meta, EvalFn Evaluator,
+                              DiagFn Diagnoser, bool AllowInjection,
+                              QualType ResultTy, SourceRange Range,
+                              ArrayRef<Expr *> Args, Decl *ContainingDecl);
 static bool is_attribute(APValue &Result, ASTContext &C,
                          MetaActions &Meta, EvalFn Evaluator,
                          DiagFn Diagnoser, bool AllowInjection,
@@ -752,6 +771,10 @@ static constexpr Metafunction Metafunctions[] = {
   { Metafunction::MFRK_metaInfo, 2, 2, get_next_member_decl_of },
   { Metafunction::MFRK_bool, 1, 1, is_structural_type },
   { Metafunction::MFRK_metaInfo, 1, 1, map_decl_to_entity },
+  { Metafunction::MFRK_bool, 1, 1, is_unscoped_attribute },
+  { Metafunction::MFRK_bool, 1, 1, is_clang_attribute },
+  { Metafunction::MFRK_bool, 1, 1, is_msvc_attribute },
+  { Metafunction::MFRK_bool, 1, 1, is_gcc_attribute },
 
   // exposed metafunctions
   { Metafunction::MFRK_spliceFromArg, 4, 4, identifier_of },
@@ -1751,6 +1774,82 @@ struct AttributeScratchpad {
 // -----------------------------------------------------------------------------
 // Metafunction implementations
 // -----------------------------------------------------------------------------
+
+bool is_unscoped_attribute(APValue &Result, ASTContext &C,
+                         MetaActions &Meta, EvalFn Evaluator,
+                         DiagFn Diagnoser, bool AllowInjection,
+                         QualType ResultTy, SourceRange Range,
+                         ArrayRef<Expr *> Args, Decl *ContainingDecl) {
+  assert(Args[0]->getType()->isReflectionType());
+  assert(ResultTy == C.BoolTy);
+  APValue RV;
+  if (!Evaluator(RV, Args[0], true))
+    return true;
+  if (RV.getReflectionKind() != ReflectionKind::Attribute) {
+    return SetAndSucceed(Result, makeBool(C, false));
+  }
+  ParsedAttr *attr = RV.getReflectedAttribute();
+  const bool isClang = attr->getForm().getSyntax() == AttributeCommonInfo::Syntax::AS_CXX11
+    && !attr->hasScope();
+  return SetAndSucceed(Result, makeBool(C, isClang));
+}
+
+bool is_clang_attribute(APValue &Result, ASTContext &C,
+                      MetaActions &Meta, EvalFn Evaluator,
+                      DiagFn Diagnoser, bool AllowInjection,
+                      QualType ResultTy, SourceRange Range,
+                      ArrayRef<Expr *> Args, Decl *ContainingDecl) {
+  assert(Args[0]->getType()->isReflectionType());
+  assert(ResultTy == C.BoolTy);
+  APValue RV;
+  if (!Evaluator(RV, Args[0], true))
+    return true;
+  if (RV.getReflectionKind() != ReflectionKind::Attribute) {
+    return SetAndSucceed(Result, makeBool(C, false));
+  }
+  ParsedAttr *attr = RV.getReflectedAttribute();
+  const bool isClang = attr->getForm().getSyntax() == AttributeCommonInfo::Syntax::AS_CXX11
+    && attr->isClangScope();
+  return SetAndSucceed(Result, makeBool(C, isClang));
+}
+
+bool is_gcc_attribute(APValue &Result, ASTContext &C,
+                    MetaActions &Meta, EvalFn Evaluator,
+                    DiagFn Diagnoser, bool AllowInjection,
+                    QualType ResultTy, SourceRange Range,
+                    ArrayRef<Expr *> Args, Decl *ContainingDecl) {
+  assert(Args[0]->getType()->isReflectionType());
+  assert(ResultTy == C.BoolTy);
+  APValue RV;
+  if (!Evaluator(RV, Args[0], true))
+    return true;
+  if (RV.getReflectionKind() != ReflectionKind::Attribute) {
+    return SetAndSucceed(Result, makeBool(C, false));
+  }
+  ParsedAttr *attr = RV.getReflectedAttribute();
+  const bool isGnu = attr->getForm().getSyntax() == AttributeCommonInfo::Syntax::AS_CXX11
+    && attr->isGNUScope();
+  return SetAndSucceed(Result, makeBool(C, isGnu));
+}
+
+bool is_msvc_attribute(APValue &Result, ASTContext &C,
+                    MetaActions &Meta, EvalFn Evaluator,
+                    DiagFn Diagnoser, bool AllowInjection,
+                    QualType ResultTy, SourceRange Range,
+                    ArrayRef<Expr *> Args, Decl *ContainingDecl) {
+  assert(Args[0]->getType()->isReflectionType());
+  assert(ResultTy == C.BoolTy);
+  APValue RV;
+  if (!Evaluator(RV, Args[0], true))
+    return true;
+  if (RV.getReflectionKind() != ReflectionKind::Attribute) {
+    return SetAndSucceed(Result, makeBool(C, false));
+  }
+  ParsedAttr *attr = RV.getReflectedAttribute();
+  const bool isGnu = attr->getForm().getSyntax() == AttributeCommonInfo::Syntax::AS_CXX11
+    && attr->isMsvcScope();
+  return SetAndSucceed(Result, makeBool(C, isGnu));
+}
 
 bool get_ith_attribute_of(APValue &Result, ASTContext &C,
                           MetaActions &Meta, EvalFn Evaluator,

--- a/clang/lib/Basic/Attributes.cpp
+++ b/clang/lib/Basic/Attributes.cpp
@@ -141,6 +141,10 @@ static StringRef normalizeAttrName(StringRef AttrName,
   return AttrName;
 }
 
+bool AttributeCommonInfo::isMsvcScope() const {
+  return ScopeName && ScopeName->isStr("msvc");
+}
+
 bool AttributeCommonInfo::isGNUScope() const {
   return ScopeName && (ScopeName->isStr("gnu") || ScopeName->isStr("__gnu__"));
 }

--- a/libcxx/include/experimental/meta
+++ b/libcxx/include/experimental/meta
@@ -26,6 +26,14 @@ inline namespace reflection_v2
 // std::meta::info
 using info = decltype(^^int);
 
+// attribute namespace
+enum class AttributeNamespace {
+  None,
+  Clang,
+  GCC,
+  MSVC,
+};
+
 // concept reflection_range
 template <typename R>
 concept reflection_range = see below;
@@ -426,6 +434,13 @@ concept reflection_range =
   same_as<ranges::range_value_t<R>, info> &&
   same_as<remove_cvref_t<ranges::range_reference_t<R>>, info>;
 
+enum class AttributeNamespace {
+  None,
+  Clang, // Exposition only
+  GCC,   // Exposition only
+  MSVC,  // Exposition only
+};
+
 namespace detail {
 enum : unsigned {
 
@@ -438,6 +453,10 @@ enum : unsigned {
   __metafn_get_next_member_decl_of,
   __metafn_is_structural_type,
   __metafn_map_decl_to_entity,
+  __metafn_is_unscoped_attribute,
+  __metafn_is_clang_attribute,
+  __metafn_is_msvc_attribute,
+  __metafn_is_gcc_attribute,
 
   // P2996 metafunctions
   __metafn_identifier_of,
@@ -770,6 +789,13 @@ struct front_annotation_of {
 };
 
 #if __has_feature(attribute_reflection)
+
+enum class AttributeNamespace {
+  None,
+  Clang, // Exposition only
+  GCC,   // Exposition only
+  MSVC,  // Exposition only
+};
 
 struct front_attribute_of {
   consteval info operator()(info reflectedEntity) const {
@@ -2202,6 +2228,26 @@ consteval auto is_attribute(info r) -> bool {
   return __metafunction(detail::__metafn_is_attribute, r);
 }
 
+// Returns whether the reflected entity is a clang scoped attribute.
+consteval auto is_unscoped_attribute(info r) -> bool {
+  return __metafunction(detail::__metafn_is_unscoped_attribute, r);
+}
+
+// Returns whether the reflected entity is a clang scoped attribute.
+consteval auto is_clang_attribute(info r) -> bool {
+  return __metafunction(detail::__metafn_is_clang_attribute, r);
+}
+
+// Returns whether the reflected entity is a gcc scoped attribute.
+consteval auto is_gcc_attribute(info r) -> bool {
+  return __metafunction(detail::__metafn_is_gcc_attribute, r);
+}
+
+// Returns whether the reflected entity is a msvc scoped attribute.
+consteval auto is_msvc_attribute(info r) -> bool {
+  return __metafunction(detail::__metafn_is_msvc_attribute, r);
+}
+
 // Return list of attribtes appertaining to r
 consteval auto attributes_of(info r) -> vector<info> {
   using iterator =
@@ -2211,6 +2257,41 @@ consteval auto attributes_of(info r) -> vector<info> {
   using range = __range_of_infos::range<iterator>;
   auto rng = range{r};
   return vector<info>{rng.begin(), rng.end()};
+}
+
+// Return list of attribtes appertaining to r, filtering on namespace and identifier
+consteval auto attributes_of(info r,
+                             std::string_view    name,
+                             AttributeNamespace ns = AttributeNamespace::None) -> vector<info> {
+  using namespace std::literals;
+
+  // For demo purpose, it's ok enough
+  // Alternative is to pass it up to the metafunction but we'd have to break our stateless iterator
+  // model.... For now, it s just not worth it (again, it's a demo).
+  auto getIdPart = [](std::string_view token) {
+    if (auto sep = token.find("::"sv); sep != std::string_view::npos && sep + 2 < token.size() ) {
+      return token.substr(sep + 2);
+    }
+    return std::string_view{};
+  };
+
+  return attributes_of(r) | views::filter([=](info attribute) {
+    switch (ns) {
+      case AttributeNamespace::None: {
+        return is_unscoped_attribute(attribute) && identifier_of(attribute) == name;
+      }
+      case AttributeNamespace::Clang: {
+        return is_clang_attribute(attribute) && getIdPart(identifier_of(attribute)) == name;
+      }
+      case AttributeNamespace::GCC: {
+        return is_gcc_attribute(attribute) && getIdPart(identifier_of(attribute)) == name;
+      }
+      case AttributeNamespace::MSVC: {
+        return is_msvc_attribute(attribute) && getIdPart(identifier_of(attribute)) == name;
+      }
+      default: return false;
+    }
+  }) | ranges::to<vector>();
 }
 
 #endif


### PR DESCRIPTION

```cpp
  #include <experimental/meta>
  constexpr auto stdAttr = ^^[[nodiscard("std variant")]];
  constexpr auto clangAttr = ^^[[clang::warn_unused_result("clang variant")]];

  struct
    [[nodiscard("std variant"), deprecated("dont use me")]]
    [[clang::warn_unused_result("clang variant")]]
    [[clang::availability(macos,introduced=10.4,deprecated=10.6,obsoleted=10.7)]]
  Foo {};

  static_assert(std::meta::attributes_of(^^Foo, "warn_unused_result", std::meta::AttributeNamespace::Clang).size() == 1);
  static_assert(std::meta::attributes_of(^^Foo, "warn_unused_result", std::meta::AttributeNamespace::Clang)[0] == clangAttr);

  static_assert(std::meta::attributes_of(^^Foo, "nodiscard").size() == 1);
  static_assert(std::meta::attributes_of(^^Foo, "nodiscard")[0] == stdAttr);
```