### PR TITLE
Variadic string , like a lot of them

### DIFF
--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang/AST/APValue.h"
+#include "clang/AST/ASTContext.h"
 #include "clang/AST/Attr.h"
 #include "clang/AST/Attrs.inc"
 #include "clang/AST/CXXInheritance.h"
@@ -718,6 +719,12 @@ static bool is_attribute(APValue &Result, ASTContext &C,
                          QualType ResultTy, SourceRange Range,
                          ArrayRef<Expr *> Args, Decl *ContainingDecl);
 
+static bool has_attribute(APValue &Result, ASTContext &C,
+                         MetaActions &Meta, EvalFn Evaluator,
+                         DiagFn Diagnoser, bool AllowInjection,
+                         QualType ResultTy, SourceRange Range,
+                         ArrayRef<Expr *> Args, Decl *ContainingDecl);
+
                           // =========================
                           // Accessibility API (P3493)
                           // =========================
@@ -884,6 +891,7 @@ static constexpr Metafunction Metafunctions[] = {
   // P3385 attributes reflection
   { Metafunction::MFRK_metaInfo, 3, 3, get_ith_attribute_of },
   { Metafunction::MFRK_bool, 1, 1, is_attribute },
+  { Metafunction::MFRK_bool, 2, 2, has_attribute },
 
   // P3493 accessibility extensions
   { Metafunction::MFRK_metaInfo, 0, 0, current_access_context },
@@ -1851,6 +1859,113 @@ bool is_msvc_attribute(APValue &Result, ASTContext &C,
   return SetAndSucceed(Result, makeBool(C, isGnu));
 }
 
+// Synthesize back a ParsedAttr from an Attr, the best I can...
+// Return a nullptr if the process met an error
+static const ParsedAttr* toSyntacticForm(const Attr* val, ASTContext * C) {
+  static AttributeScratchpad scratchpad;
+  ParsedAttr * recoveredAttr = nullptr;
+  auto onArgs = [&](
+      IdentifierInfo * attrName,
+      SmallVector<llvm::PointerUnion<Expr *, IdentifierLoc *>, 2> argExprs,
+      AttributeCommonInfo::Form /* Do we need this fed back to us at all ?...*/
+    ) {
+      recoveredAttr = scratchpad.pool.create(
+        attrName,
+        val->getRange(),
+        val->hasScope() ? const_cast<IdentifierInfo*>(val->getScopeName()) : nullptr,
+        val->getLoc(),
+        argExprs.data(),
+        argExprs.size(),
+        val->getForm()
+      );
+      return recoveredAttr != nullptr;
+    };
+    // FIXME why is this not just returning the vector of args...
+    // Did I worry about lifetime... ?
+    if (!extractSyntacticArguments(val, *C, onArgs, val->getLocation())) {
+      recoveredAttr = nullptr;
+    }
+    return recoveredAttr;
+}
+
+bool has_attribute(APValue &Result, ASTContext &C,
+                  MetaActions &Meta, EvalFn Evaluator,
+                  DiagFn Diagnoser, bool AllowInjection,
+                  QualType ResultTy, SourceRange Range,
+                  ArrayRef<Expr *> Args, Decl *ContainingDecl) {
+  assert(Args[0]->getType()->isReflectionType());
+  APValue RV;
+  if (!Evaluator(RV, Args[0], true))
+    return true;
+
+  assert(ResultTy == C.BoolTy);
+  assert(Args[1]->getType()->isReflectionType());
+  if (!Evaluator(RV, Args[1], true))
+    return true;
+  if (RV.getReflectionKind() != ReflectionKind::Attribute) {
+    return SetAndSucceed(Result, makeBool(C, false));
+  }
+  const ParsedAttr* testAttr = RV.getReflectedAttribute();
+
+  auto findMatchingAttribute = [&](Decl* decl, const ParsedAttr* testAttr) -> bool {
+    llvm::FoldingSetNodeID providedAttrID;
+    testAttr->profile(providedAttrID);
+
+    auto cxx11Attrs = collectUniqueCxx11Attrs(decl);
+    if (cxx11Attrs.empty()) {
+      return false;
+    }
+    for (const auto * val : cxx11Attrs) {
+      assert(val);
+      const ParsedAttr * recoveredAttr = toSyntacticForm(val, &C);
+      llvm::FoldingSetNodeID recoveredAttrID;
+      recoveredAttr->profile(recoveredAttrID);
+      if (recoveredAttrID == providedAttrID) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  switch (RV.getReflectionKind()) {
+    default: return DiagnoseReflectionKind(Diagnoser, Range, "variable, attribute, function, namespace", DescriptionOf(RV));
+    case ReflectionKind::Attribute: { // Somewhat useless...
+      llvm::FoldingSetNodeID testAttrID;
+      testAttr->profile(testAttrID);
+      const ParsedAttr* reflectedAttr = RV.getReflectedAttribute();
+      llvm::FoldingSetNodeID reflectedAttrID;
+      reflectedAttr->profile(reflectedAttrID);
+
+      return SetAndSucceed(Result, makeBool(C, reflectedAttrID == testAttrID));
+    }
+    case ReflectionKind::Type: {
+      QualType qType = RV.getReflectedType();
+      Decl *D = findTypeDecl(qType)->getMostRecentDecl();
+      if (!D) {
+        return Diagnoser(Range.getBegin(), diag::metafn_p3385_no_declaration_for_type)
+          << DescriptionOf(RV);
+      }
+      return SetAndSucceed(Result, makeBool(C, findMatchingAttribute(D, testAttr)));
+    }
+    case ReflectionKind::Declaration: {
+      ValueDecl *D = RV.getReflectedDecl();
+      if (!D) {
+        return DiagnoseReflectionKind(
+          Diagnoser, Range, "attribute, type, declaration", DescriptionOf(RV));
+      }
+      return SetAndSucceed(Result, makeBool(C, findMatchingAttribute(D, testAttr)));
+    }
+    case ReflectionKind::Namespace: {
+      Decl* D = RV.getReflectedNamespace()->getMostRecentDecl();
+      if (!D) {
+        return DiagnoseReflectionKind(
+          Diagnoser, Range, "attribute, type, declaration", DescriptionOf(RV));
+      }
+      return SetAndSucceed(Result, makeBool(C, findMatchingAttribute(D, testAttr)));
+    }
+  }
+}
+
 bool get_ith_attribute_of(APValue &Result, ASTContext &C,
                           MetaActions &Meta, EvalFn Evaluator,
                           DiagFn Diagnoser, bool AllowInjection,
@@ -1873,38 +1988,20 @@ bool get_ith_attribute_of(APValue &Result, ASTContext &C,
     return true;
   size_t idx = Idx.getInt().getExtValue();
 
-  // FIXME this is debatable whether those shouldnt be kept in ASTContext...
-  static AttributeScratchpad scratchpad;
-  auto buildIthParsedAttrFromDecl = [&](Decl* decl, ParsedAttr* &result) -> bool {
+  auto buildIthParsedAttrFromDecl = [&](size_t i, Decl* decl, const ParsedAttr* &result) -> bool {
     auto cxx11Attrs = collectUniqueCxx11Attrs(decl);
-    if (idx + 1 > cxx11Attrs.size()) {
+    if (i + 1 > cxx11Attrs.size()) {
       result = nullptr;
-      return false;
+      return true;
     }
-
-    const Attr * val = cxx11Attrs[idx];
+    const Attr * val = cxx11Attrs[i];
     assert(val);
-
-    auto onSyntacticArgs = [&](
-      IdentifierInfo * attrName,
-      SmallVector<llvm::PointerUnion<Expr *, IdentifierLoc *>, 2> argExprs,
-      AttributeCommonInfo::Form /* Do we need this fed back to us at all ?...*/
-    ) {
-      result = scratchpad.pool.create(
-        attrName,
-        val->getRange(),
-        val->hasScope() ? const_cast<IdentifierInfo*>(val->getScopeName()) : nullptr,
-        val->getLoc(),
-        argExprs.data(),
-        argExprs.size(),
-        val->getForm()
-      );
-      return false;
-    };
-    return extractSyntacticArguments(val, C, onSyntacticArgs, val->getLocation());
+    result = toSyntacticForm(val, &C);
+    return result != nullptr;
   };
 
   switch (RV.getReflectionKind()) {
+    default: return DiagnoseReflectionKind(Diagnoser, Range, "variable, attribute, function, namespace", DescriptionOf(RV));
     case ReflectionKind::Attribute: {
       if (idx != 0) {
         return SetAndSucceed(Result, Sentinel);
@@ -1924,10 +2021,11 @@ bool get_ith_attribute_of(APValue &Result, ASTContext &C,
           << DescriptionOf(RV);
       }
 
-      if (ParsedAttr* fetchedAttribute{}; !buildIthParsedAttrFromDecl(D, fetchedAttribute)) {
+      if (const ParsedAttr* fetchedAttribute{}; buildIthParsedAttrFromDecl(idx, D, fetchedAttribute)) {
         if (fetchedAttribute) {
           return SetAndSucceed(Result, makeReflection(fetchedAttribute));
         }
+        // Reached the end
         return SetAndSucceed(Result, Sentinel);
       }
       return true;
@@ -1936,10 +2034,24 @@ bool get_ith_attribute_of(APValue &Result, ASTContext &C,
       ValueDecl *D = RV.getReflectedDecl();
       if (!D) {
         return DiagnoseReflectionKind(
-          Diagnoser, Range, "attribute, type, declaration", DescriptionOf(RV));
+          Diagnoser, Range, "attribute, type, variable, namespace", DescriptionOf(RV));
       }
 
-      if (ParsedAttr* fetchedAttribute{}; !buildIthParsedAttrFromDecl(D, fetchedAttribute)) {
+      if (const ParsedAttr* fetchedAttribute{}; buildIthParsedAttrFromDecl(idx, D, fetchedAttribute)) {
+        if (fetchedAttribute) {
+          return SetAndSucceed(Result, makeReflection(fetchedAttribute));
+        }
+        return SetAndSucceed(Result, Sentinel);
+      }
+      return true;
+    }
+    case ReflectionKind::Namespace: {
+      Decl* D = RV.getReflectedNamespace();
+      if (!D) {
+        return DiagnoseReflectionKind(
+          Diagnoser, Range, "attribute, type, variable, namespace", DescriptionOf(RV));
+      }
+      if (const ParsedAttr* fetchedAttribute{}; buildIthParsedAttrFromDecl(idx, D, fetchedAttribute)) {
         if (fetchedAttribute) {
           return SetAndSucceed(Result, makeReflection(fetchedAttribute));
         }
@@ -1948,18 +2060,7 @@ bool get_ith_attribute_of(APValue &Result, ASTContext &C,
       return true;
     }
     case ReflectionKind::Null:
-      return Diagnoser(Range.getBegin(), diag::metafn_p3385_attributes_of_null)
-        << Range;
-    case ReflectionKind::Template:
-    case ReflectionKind::Object:
-    case ReflectionKind::Value:
-    case ReflectionKind::Namespace:
-    case ReflectionKind::BaseSpecifier:
-    case ReflectionKind::DataMemberSpec:
-    case ReflectionKind::Annotation:
-    case ReflectionKind::EntityProxy:
-      return DiagnoseReflectionKind(Diagnoser, Range, "declaration or attribute",
-                                    DescriptionOf(RV));
+      return Diagnoser(Range.getBegin(), diag::metafn_p3385_attributes_of_null) << Range;
   }
   llvm_unreachable("unknown reflection kind");
   return false;
@@ -4341,7 +4442,7 @@ bool is_attribute(APValue &Result, ASTContext &C,
   assert(ResultTy == C.BoolTy);
   APValue RV;
   if (!Evaluator(RV, Args[0], true))
-  return true;
+    return true;
 
   return SetAndSucceed(Result, makeBool(C, RV.isReflectedAttribute()));
 }

--- a/clang/utils/TableGen/ClangAttrEmitter.cpp
+++ b/clang/utils/TableGen/ClangAttrEmitter.cpp
@@ -2564,15 +2564,6 @@ static bool isIntArgument(const Record *Arg) {
       .Default(false);
 }
 
-static bool isStringLiteralArgument(const Record *Arg) {
-  if (Arg->getDirectSuperClasses().empty())
-    return false;
-  StringRef ArgKind = Arg->getDirectSuperClasses().back().first->getName();
-  if (ArgKind == "EnumArgument")
-    return Arg->getValueAsBit("IsString");
-  return ArgKind == "StringArgument";
-}
-
 static bool isStringEnumArgument(const Record *Arg) {
   if (Arg->getDirectSuperClasses().empty())
     return false;
@@ -2580,13 +2571,23 @@ static bool isStringEnumArgument(const Record *Arg) {
   return ArgKind == "EnumArgument" && Arg->getValueAsBit("IsString");
 }
 
-static bool isVariadicStringLiteralArgument(const Record *Arg) {
+static bool isStringLiteralArgument(const Record *Arg) {
+  StringRef ArgKind = Arg->getDirectSuperClasses().back().first->getName();
+  return isStringEnumArgument(Arg) || ArgKind == "StringArgument";
+}
+
+static bool isVariadicStringLiteralEnumArgument(const Record *Arg) {
   if (Arg->getDirectSuperClasses().empty())
     return false;
   StringRef ArgKind = Arg->getDirectSuperClasses().back().first->getName();
   if (ArgKind == "VariadicEnumArgument")
     return Arg->getValueAsBit("IsString");
-  return ArgKind == "VariadicStringArgument";
+  return false;
+}
+
+static bool isVariadicStringLiteralArgument(const Record *Arg) {
+  StringRef ArgKind = Arg->getDirectSuperClasses().back().first->getName();
+  return isVariadicStringLiteralEnumArgument(Arg) || ArgKind == "VariadicStringArgument";
 }
 
 // An (family-of-variant) attribute is reflectable if
@@ -2621,6 +2622,7 @@ static bool isReflectableAttr(const Record* R) {
 
   auto isSupportedArgType = [](const Record* arg) {
     return isStringLiteralArgument(arg)
+      || isVariadicStringLiteralArgument(arg)
       || isBoolArgument(arg)
       || isIntArgument(arg)
       || isExprArgument(arg);
@@ -2647,6 +2649,8 @@ static void writeExtractSyntacticArgumentFunction(const Record &R,
   };
 
   auto emitExprFromArg = [&] (raw_ostream &OS, const Record *Arg) {
+    // I dont have an Arg here so cant directly call
+    // all the normalization methods...
     std::string ArgName(Arg->getValueAsString("Name"));
     ArgName[0] = std::toupper(ArgName[0]);
     std::string Accessor = std::string("get") + ArgName + "()";
@@ -2658,6 +2662,36 @@ static void writeExtractSyntacticArgumentFunction(const Record &R,
     } else if (isIdentifierArgument(Arg, true)) {
       OS << "    IdentifierLoc *IL" << ArgName << " = new (C) IdentifierLoc(srcLocation, " << Accessor << ");\n";
       OS << "    args.push_back(IL" << ArgName << ");\n";
+    } else if (isVariadicStringLiteralArgument(Arg)) {
+      // no 'get', no uppercase
+      std::string variadicAccessorName = ArgName;
+      variadicAccessorName[0] = std::tolower(variadicAccessorName[0]);
+      variadicAccessorName += "()";
+      if (!isVariadicStringLiteralEnumArgument(Arg)) {
+        // No need to convert enum to their string representation
+        OS << "    for (auto it : " << variadicAccessorName<< ") {"
+           << "      args.push_back(StringLiteral::Create(\n"
+           << "        C,\n"
+           << "        it,\n"
+           << "        StringLiteralKind::Unevaluated,\n"
+           << "        false,\n"
+           << "        C.getConstantArrayType(C.CharTy, llvm::APInt(32, it.size() + 1), nullptr, ArraySizeModifier::Normal, 0),\n"
+           << "        srcLocation));\n"
+           << "    }\n";
+      } else {
+        std::string enumTypeName(makeShortNameForArgType(Arg));
+        enumTypeName[0] = std::toupper(enumTypeName[0]);
+        std::string variadicConvertorName = "StringRef(Convert" + enumTypeName + "ToStr(it))";
+        OS << "    for (auto it : " << variadicAccessorName<< ") {"
+           << "      args.push_back(StringLiteral::Create(\n"
+           << "        C,\n"
+           << "        " << variadicConvertorName << ",\n"
+           << "        StringLiteralKind::Unevaluated,\n"
+           << "        false,\n"
+           << "        C.getConstantArrayType(C.CharTy, llvm::APInt(32, " << variadicConvertorName << ".size() + 1), nullptr, ArraySizeModifier::Normal, 0),\n"
+           << "        srcLocation));\n"
+           << "    }\n";
+      }
     } else if (isStringLiteralArgument(Arg)) {
       // String enums need to go through a convert
       if (isStringEnumArgument(Arg)) {

--- a/libcxx/include/experimental/meta
+++ b/libcxx/include/experimental/meta
@@ -566,6 +566,7 @@ enum : unsigned {
   // P3385 attributes reflection
   __metafn_get_ith_attribute_of,
   __metafn_is_attribute,
+  __metafn_has_attribute,
 
   // P3493 accessibility metafunctions
   __metafn_access_context,
@@ -2226,6 +2227,12 @@ consteval auto annotate(info entity, info val) -> info {
 // Returns whether the reflected entity is an attribute.
 consteval auto is_attribute(info r) -> bool {
   return __metafunction(detail::__metafn_is_attribute, r);
+}
+
+// Return true if the given 'entity' has the given 'attribute' appertained
+// to it
+consteval auto has_attribute(info entity, info attribute) -> bool {
+  return __metafunction(detail::__metafn_has_attribute, entity, attribute);
 }
 
 // Returns whether the reflected entity is a clang scoped attribute.

--- a/libcxx/test/std/experimental/reflection/p3385-attributes.pass.cpp
+++ b/libcxx/test/std/experimental/reflection/p3385-attributes.pass.cpp
@@ -18,20 +18,34 @@
 // [reflection]
 #include <experimental/meta>
 
-// Note that 'Foo' mix standard and vendor namespaced, supported and unsupported
-struct [[nodiscard("std variant"), deprecated("dont use me")]]
+// 'Foo' mix standard and vendor namespaced, supported and unsupported
+struct [[nodiscard("Standard nodiscard"), deprecated("Standard deprecated")]]
 [[clang::warn_unused_result("clang variant")]]
 [[clang::availability(macos,introduced=10.4,deprecated=10.6,obsoleted=10.7)]] Foo {};
 
-// This is vendor specific & does not exist in the standard
+// This is vendor specific, does not exist in the standard
 [[gnu::constructor(200)]] void gnuConstructor(void);
 
+// NS and function
+namespace [[deprecated("Standard deprecated")]] DeprecatedNamespace {}
+[[deprecated("Standard deprecated")]] bool DeprecatedFunction() {}
+
+// Test for variadic string
+class [[clang::suppress("one", "two", "three")]] Bar {};
+
+// Test for variadic enum
+struct [[clang::consumable(unconsumed)]] FooBar {
+    [[clang::callable_when(unconsumed)]] void f() {}
+};
+
 // Some samples of vendor and standard attributes
-constexpr auto stdAttr = ^^[[nodiscard("std variant")]];
+constexpr auto stdAttr = ^^[[nodiscard("Standard nodiscard")]];
 constexpr auto clangAttr = ^^[[clang::warn_unused_result("clang variant")]];
 constexpr auto msvcAttr = ^^[[msvc::no_unique_address]];
 constexpr auto gnuAttr = ^^[[gnu::constructor(200)]];
-
+constexpr auto variadicAttr = ^^[[clang::suppress("one", "two", "three")]];
+constexpr auto enumAttr = ^^[[clang::callable_when(unconsumed)]];
+constexpr auto stdDeprecated = ^^[[deprecated("Standard deprecated")]];
 
 // Test fragments
 consteval bool testHasIdentifier() {
@@ -58,6 +72,14 @@ consteval bool testIdentifierOf() {
   return true;
 }
 
+consteval bool testHasAttr() {
+  static_assert(std::meta::has_attribute(^^Foo, stdAttr));
+  static_assert(std::meta::has_attribute(^^Foo, stdDeprecated));
+  static_assert(std::meta::has_attribute(^^Foo, clangAttr));
+  static_assert(!std::meta::has_attribute(^^Foo, ^^[[clang::availability(macos,introduced=10.4,deprecated=10.6,obsoleted=10.7)]]));
+  return true;
+}
+
 consteval bool testAttributesOfAttr() {
   static_assert(std::meta::attributes_of(stdAttr)[0] == stdAttr);
   static_assert(std::meta::attributes_of(clangAttr)[0] == clangAttr);
@@ -66,24 +88,29 @@ consteval bool testAttributesOfAttr() {
   return true;
 }
 
-consteval bool testAttributesOfType() {
-  constexpr auto h = [](std::meta::info i) {
-    return i == ^^[[nodiscard("std variant")]]
-      || i == ^^[[deprecated("dont use me")]]
-      || i == ^^[[clang::warn_unused_result("clang variant")]];
-  };
+consteval bool testAttributesofNs() {
+  static_assert(std::meta::has_attribute(^^DeprecatedNamespace, stdDeprecated));
+  return true;
+}
 
+consteval bool testAttributesofFunction() {
+  static_assert(std::meta::has_attribute(^^DeprecatedFunction, stdDeprecated));
+  return true;
+}
+
+consteval bool testAttributesOfType() {
   // This should not return the unsupported 'availability'
   static_assert(std::meta::attributes_of(^^Foo).size() == 3);
   
-  constexpr auto att0 = std::meta::attributes_of(^^Foo)[0];
-  constexpr auto att1 = std::meta::attributes_of(^^Foo)[1];
-  constexpr auto att2 = std::meta::attributes_of(^^Foo)[2];
-  
-  static_assert(att0 != att1 && att1 != att2 && att0 != att2);
-  static_assert(h(att0));
-  static_assert(h(att1));
-  static_assert(h(att2));
+  static_assert(std::meta::has_attribute(^^Foo, stdAttr));
+  static_assert(std::meta::has_attribute(^^Foo, stdDeprecated));
+  static_assert(std::meta::has_attribute(^^Foo, clangAttr));
+
+  static_assert(std::meta::attributes_of(^^Foo, "warn_unused_result", std::meta::AttributeNamespace::Clang).size() == 1);
+  static_assert(std::meta::attributes_of(^^Foo, "warn_unused_result", std::meta::AttributeNamespace::Clang)[0] == clangAttr);
+
+  static_assert(std::meta::attributes_of(^^Foo, "nodiscard").size() == 1);
+  static_assert(std::meta::attributes_of(^^Foo, "nodiscard")[0] == stdAttr);
 
   return true;
 }
@@ -103,26 +130,66 @@ consteval bool testComparison() {
 consteval bool testVendorSpecific() {
   constexpr auto r = ^^gnuConstructor;
   static_assert(std::meta::attributes_of(r).size() == 1);
-  static_assert(std::meta::attributes_of(r)[0] == ^^[[gnu::constructor(200)]]);
+  static_assert(std::meta::attributes_of(r)[0] == gnuAttr);
   return true;
 }
 
-consteval bool testUnsupported() {
-  static_assert(!std::meta::is_attribute(^^[[assume(true)]]));
-  static_assert(!std::meta::is_attribute(^^[[clang::assume(true)]]));
+consteval bool testUnsupportedAttributes() {
   static_assert(!std::meta::is_attribute(^^[[my::stuff("anything")]]));
-  static_assert(^^[[assume(true)]] == std::meta::info());
+  return true;
+}
+
+consteval bool testVariadicStringArgument() {
+  static_assert(std::meta::attributes_of(^^Bar).size() == 1);
+  static_assert(std::meta::attributes_of(^^Bar, "suppress", std::meta::AttributeNamespace::Clang)[0] == variadicAttr);
+  static_assert(std::meta::attributes_of(^^Bar, "suppress", std::meta::AttributeNamespace::Clang)[0] != ^^[[clang::suppress("one", "too", "three")]]); // typo on 'two'
+  return true;
+}
+
+consteval bool testVariadicEnumArgument() {
+  constexpr auto r = ^^FooBar::f;
+  static_assert(std::meta::identifier_of(r) == "f");
+  static_assert(std::meta::attributes_of(r).size() == 1);
+  static_assert(std::meta::attributes_of(r)[0] == enumAttr);
+  return true;
+}
+
+struct TestDefineAggregate {
+  struct Impl;
+  consteval {
+    constexpr auto r = std::meta::data_member_spec(
+      ^^int,
+      std::meta::data_member_options{
+        .name= "idx",
+        .attributes = { ^^[[maybe_unused]], ^^[[no_unique_address]] }
+      }
+    );
+
+    std::meta::define_aggregate(
+      ^^Impl, {
+        r
+      }
+    );
+  }
+};
+static_assert(std::meta::is_complete_type(^^TestDefineAggregate::Impl));
+static_assert(std::meta::attributes_of(std::meta::nonstatic_data_members_of(
+                  ^^TestDefineAggregate::Impl, std::meta::access_context::current())[0]).size() == 2);
+
+consteval bool testAssumeAttribute() {
+  static_assert(std::meta::is_attribute(^^[[assume(true)]]));
+  static_assert(std::meta::is_attribute(^^[[clang::assume(true)]]));
+
+  static_assert(^^[[assume(true)]] == ^^[[assume(true)]]);
+  static_assert(^^[[assume(true)]] != ^^[[assume(false)]]);
+  int i = 0;
+  static_assert(^^[[assume(i > 0)]] != ^^[[assume(i == 0)]]);
+  static_assert(^^[[assume(i != 0)]] == ^^[[assume(i != 0)]]);
+
   return true;
 }
 
 int main() {
-  static_assert(testIsAttribute(), "IsAttribute");
-  static_assert(testHasIdentifier(), "HasIdentifier");
-  static_assert(testIdentifierOf(), "IdentifierOf");
-  static_assert(testAttributesOfAttr() ,"AttributesOfAttr");
-  static_assert(testAttributesOfType() ,"AttributesOfType");
-  static_assert(testComparison() ,"Comparison");
-  static_assert(testVendorSpecific() ,"VendorSpecific");
-  static_assert(testUnsupported() ,"Unsupported");
+  return 0;
 }
 


### PR DESCRIPTION
Support to synthesize attributes with args
- [x] pure string 
- [x] string like enum

This also add a `has_attribute(info, info)` convenience function and a (unproposed) filtering to `attributes_of` via namespace and token

```cpp
  class [[clang::suppress("one", "two", "three")]] Bar {};
  constexpr auto variadicAttr = ^^[[clang::suppress("one", "two", "three")]];

　struct [[clang::consumable(unconsumed)]] FooBar {
　　[[clang::callable_when(unconsumed)]] void f() {}
　};

  static_assert(std::meta::attributes_of(^^Bar).size() == 1);
  static_assert(std::meta::attributes_of(^^Bar, "suppress", std::meta::AttributeNamespace::Clang)[0] == variadicAttr);
  static_assert(std::meta::attributes_of(^^Bar, "suppress", std::meta::AttributeNamespace::Clang)[0] != ^^[[clang::suppress("one", "too", "three")]]); // typo on 'two'

  static_assert(std::meta::attributes_of(^^FooBar::f).size() == 1);
  static_assert(std::meta::has_attribute(^^FooBar::f, ^^[[clang::callable_when(unconsumed)]]));
```

