### PR TITLE
Reflect over unsupported attribute is an error

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -3256,8 +3256,8 @@ def err_cannot_expand_over_type : Error<
 // P3385
 def p3385_sema_trace_execution_checkpoint : Warning<
   "(p3385-Sema) trace_execution_checkpoint %0">;
-def p3385_warn_unsupported_attribute : Warning<
-  "reflecting over '%0' attribute is not supported">;
+def p3385_warn_unsupported_attribute : Error<
+  "reflecting over the unsupported '%0' attribute is ill-formed">;
 
 // C++11 char16_t/char32_t
 def warn_cxx98_compat_unicode_type : Warning<

--- a/clang/lib/Parse/ParseReflect.cpp
+++ b/clang/lib/Parse/ParseReflect.cpp
@@ -18,6 +18,7 @@
 #include "clang/Parse/Parser.h"
 #include "clang/Parse/RAIIObjectsForParser.h"
 #include "clang/Sema/EnterExpressionEvaluationContext.h"
+#include "clang/Sema/Ownership.h"
 #include "clang/Sema/ParsedAttr.h"
 using namespace clang;
 
@@ -85,23 +86,30 @@ ExprResult Parser::ParseCXXReflectExpression(SourceLocation OpLoc) {
   }
   TentativeAction.Revert();
 
-  // Check for a standard attribute
+  // Check for attribute
   {
     size_t last = Attrs.size();
     if (MaybeParseCXX11Attributes(Attrs)) {
       size_t newLast = Attrs.size();
 
-      // FIXME handle empty [[]] gracefully
+      // Reflect expression of empty attribute list is ill formed
       if (last == newLast) {
         Diag(OperandLoc, diag::p3385_trace_empty_attributes_list);
         return ExprError();
       }
+      // Reflect expression of multiple attributes is ill formed
       if (newLast - last > 1) {
         Diag(OperandLoc, diag::p3385_err_attributes_list) << (newLast - last);
         return ExprError();
       }
-
-      return Actions.ActOnCXXReflectExpr(OpLoc, &Attrs.back());
+      // Reflects expression of unsupported attribute is ill formed
+      auto * attribute = &Attrs.back();
+      bool isReflectable = isAttributeWithReflectableVariant(attribute->getParsedKind());
+      if (!isReflectable) {
+        Diag(OpLoc, diag::p3385_warn_unsupported_attribute) << attribute->getAttrName()->getName();
+        return ExprError();
+      }
+      return Actions.ActOnCXXReflectExpr(OpLoc, attribute);
     }
   }
 

--- a/clang/lib/Sema/SemaReflect.cpp
+++ b/clang/lib/Sema/SemaReflect.cpp
@@ -1341,15 +1341,9 @@ ExprResult Sema::BuildCXXReflectExpr(SourceLocation OperatorLoc,
 
 ExprResult Sema::BuildCXXReflectExpr(SourceLocation OperatorLoc,
                                      ParsedAttr *A) {
-  bool isReflectable = isAttributeWithReflectableVariant(A->getParsedKind());
-  if (!isReflectable) {
-    Diag(A->getLoc(), diag::p3385_warn_unsupported_attribute)
-        << A->getAttrName()->getName();
-  }
   return CXXReflectExpr::Create(
       Context, OperatorLoc, A->getRange(),
-      APValue{isReflectable ? ReflectionKind::Attribute : ReflectionKind::Null,
-              static_cast<void *>(isReflectable ? A : nullptr)});
+      APValue{ReflectionKind::Attribute, static_cast<void *>(A)});
 }
 
 ExprResult Sema::BuildCXXMetafunctionExpr(

--- a/libcxx/test/std/experimental/reflection/p3385-attributes.pass.cpp
+++ b/libcxx/test/std/experimental/reflection/p3385-attributes.pass.cpp
@@ -78,7 +78,6 @@ consteval bool testHasAttr() {
     && std::meta::has_attribute(^^Foo, stdDeprecated)
     && std::meta::has_attribute(^^Foo, clangAttr)
   );
-  static_assert(!std::meta::has_attribute(^^Foo, ^^[[clang::availability(macos,introduced=10.4,deprecated=10.6,obsoleted=10.7)]]));
   static_assert(std::meta::has_attribute(^^DeprecatedNamespace, stdDeprecated));
   static_assert(std::meta::has_attribute(^^DeprecatedFunction, stdDeprecated));
   return true;
@@ -139,7 +138,8 @@ consteval bool testVendorSpecific() {
 }
 
 consteval bool testUnsupportedAttributes() {
-  static_assert(!std::meta::is_attribute(^^[[my::stuff("anything")]]));
+  static_assert(!std::meta::is_attribute(^^[[my::stuff("anything")]])); // expected-error {{reflecting over the unsupported 'availability' attribute is ill-formed}}
+  static_assert(!std::meta::is_attribute(^^[[clang::availability(macos,introduced=10.4,deprecated=10.6,obsoleted=10.7)]])); // expected-error {{reflecting over the unsupported 'stuff' attribute is ill-formed}}
   return true;
 }
 


### PR DESCRIPTION
Reflecting over unsupported attribute does not yield a null reflection but is ill formed