### PR TITLE
Allow policy on has_attribute comparison

### DIFF
--- a/clang/include/clang/Sema/ParsedAttr.h
+++ b/clang/include/clang/Sema/ParsedAttr.h
@@ -373,8 +373,11 @@ public:
   /// getNumArgs - Return the number of actual arguments to this attribute.
   unsigned getNumArgs() const { return NumArgs; }
 
-  /// profile the current parsed attribute
-  void profile(llvm::FoldingSetNodeID& ID) const;
+  /// profile the current parsed attribute, the later arguments determines whether
+  //  those components of the attribute participate in the built up profile
+  void profile(llvm::FoldingSetNodeID& ID, 
+               bool isContributingNamespace = true,
+               bool isContributingArgument = true) const;
 
   /// getArg - Return the specified argument.
   ArgsUnion getArg(unsigned Arg) const {

--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -891,7 +891,7 @@ static constexpr Metafunction Metafunctions[] = {
   // P3385 attributes reflection
   { Metafunction::MFRK_metaInfo, 3, 3, get_ith_attribute_of },
   { Metafunction::MFRK_bool, 1, 1, is_attribute },
-  { Metafunction::MFRK_bool, 2, 2, has_attribute },
+  { Metafunction::MFRK_bool, 3, 3, has_attribute },
 
   // P3493 accessibility extensions
   { Metafunction::MFRK_metaInfo, 0, 0, current_access_context },
@@ -1888,6 +1888,12 @@ static const ParsedAttr* toSyntacticForm(const Attr* val, ASTContext * C) {
     return recoveredAttr;
 }
 
+enum class AttributeComparison : int64_t {
+  Default         = 1 << 0,
+  IgnoreNamespace = 1 << 1, // Namespace is ignored during the comparison
+  IgnoreArgument  = 1 << 2, // The argument is ignored during the comparison
+};
+
 bool has_attribute(APValue &Result, ASTContext &C,
                   MetaActions &Meta, EvalFn Evaluator,
                   DiagFn Diagnoser, bool AllowInjection,
@@ -1896,6 +1902,17 @@ bool has_attribute(APValue &Result, ASTContext &C,
   APValue RV;
 
   assert(ResultTy == C.BoolTy);
+
+  // Policy
+  assert(Args[2]->getType()->isIntegralOrEnumerationType());
+  if (!Evaluator(RV, Args[2], true)) {
+    return true;
+  }
+  const int64_t policy = RV.getInt().getExtValue();
+  const bool isContributingNamespace = (policy & static_cast<int64_t>(AttributeComparison::IgnoreNamespace)) == 0;
+  const bool isContributingArgument = (policy & static_cast<int64_t>(AttributeComparison::IgnoreArgument)) == 0;
+
+  // Attribute to look for
   assert(Args[1]->getType()->isReflectionType());
   if (!Evaluator(RV, Args[1], true)) {
     return true;
@@ -1905,6 +1922,7 @@ bool has_attribute(APValue &Result, ASTContext &C,
   }
   const ParsedAttr* testAttr = RV.getReflectedAttribute();
 
+  // Entity to inspect
   assert(Args[0]->getType()->isReflectionType());
   if (!Evaluator(RV, Args[0], true)) {
     return true;
@@ -1912,7 +1930,7 @@ bool has_attribute(APValue &Result, ASTContext &C,
 
   auto findMatchingAttribute = [&](Decl* decl, const ParsedAttr* testAttr) -> bool {
     llvm::FoldingSetNodeID providedAttrID;
-    testAttr->profile(providedAttrID);
+    testAttr->profile(providedAttrID, isContributingNamespace, isContributingArgument);
 
     auto cxx11Attrs = collectUniqueCxx11Attrs(decl);
     if (cxx11Attrs.empty()) {
@@ -1922,7 +1940,7 @@ bool has_attribute(APValue &Result, ASTContext &C,
       assert(val);
       const ParsedAttr * recoveredAttr = toSyntacticForm(val, &C);
       llvm::FoldingSetNodeID recoveredAttrID;
-      recoveredAttr->profile(recoveredAttrID);
+      recoveredAttr->profile(recoveredAttrID, isContributingNamespace, isContributingArgument);
       if (recoveredAttrID == providedAttrID) {
         return true;
       }

--- a/clang/lib/Sema/ParsedAttr.cpp
+++ b/clang/lib/Sema/ParsedAttr.cpp
@@ -350,16 +350,18 @@ static void ProfileExpr(llvm::FoldingSetNodeID& ID, const Expr* E) {
   }
 }
 
-void ParsedAttr::profile(llvm::FoldingSetNodeID& ID) const
+void ParsedAttr::profile(llvm::FoldingSetNodeID& ID, 
+                         bool isContributingNamespace,
+                         bool isContributingArgument) const
 {
   // Add syntax form
   ID.AddInteger(getSyntax());
 
-  // Add the attribute kind and spelling index
-  ID.AddInteger(getAttributeSpellingListIndex());
+  // Add the attribute kind
+  ID.AddInteger(getKind());
 
   // Add the scope name if present
-  if (hasScope()) {
+  if (isContributingNamespace && hasScope()) {
     StringRef scopeName = getScopeName()->getName();
     ID.AddInteger(scopeName.size());
     ID.AddString(scopeName);
@@ -373,6 +375,9 @@ void ParsedAttr::profile(llvm::FoldingSetNodeID& ID) const
   ID.AddInteger(attrName.size());
   ID.AddString(attrName);
 
+  if (!isContributingArgument) {
+    return;
+  }
   // Add attribute arguments
   ID.AddInteger(getNumArgs());
   for (unsigned i = 0; i < getNumArgs(); ++i) {

--- a/libcxx/include/experimental/meta
+++ b/libcxx/include/experimental/meta
@@ -2229,10 +2229,26 @@ consteval auto is_attribute(info r) -> bool {
   return __metafunction(detail::__metafn_is_attribute, r);
 }
 
+
+enum class AttributeComparison : int64_t {
+  Default         = 1 << 0,
+  IgnoreNamespace = 1 << 1, // Namespace is ignored during the comparison
+  IgnoreArgument  = 1 << 2, // The argument is ignored during the comparison
+};
+
+constexpr AttributeComparison operator|(AttributeComparison a, AttributeComparison b) noexcept {
+  return static_cast<AttributeComparison>(
+    static_cast<int64_t>(a) | static_cast<int64_t>(b));
+}
+
 // Return true if the given 'entity' has the given 'attribute' appertained
-// to it
-consteval auto has_attribute(info entity, info attribute) -> bool {
-  return __metafunction(detail::__metafn_has_attribute, entity, attribute);
+// to it. The given 'policy' dictates what participates to the comparisons
+consteval auto has_attribute(
+  info entity,
+  info attribute,
+  AttributeComparison policy = AttributeComparison::Default
+) -> bool {
+  return __metafunction(detail::__metafn_has_attribute, entity, attribute, policy);
 }
 
 // Returns whether the reflected entity is a clang scoped attribute.

--- a/libcxx/test/std/experimental/reflection/p3385-attributes.pass.cpp
+++ b/libcxx/test/std/experimental/reflection/p3385-attributes.pass.cpp
@@ -80,6 +80,24 @@ consteval bool testHasAttr() {
   );
   static_assert(std::meta::has_attribute(^^DeprecatedNamespace, stdDeprecated));
   static_assert(std::meta::has_attribute(^^DeprecatedFunction, stdDeprecated));
+  // Ignore the argument only
+  static_assert(std::meta::has_attribute(
+    ^^DeprecatedFunction,
+    ^^[[deprecated]],
+    std::meta::AttributeComparison::IgnoreArgument
+  ));
+  // Ignore the namespace only
+  static_assert(std::meta::has_attribute(
+    ^^DeprecatedFunction,
+    ^^[[gnu::deprecated("Standard deprecated")]],
+    std::meta::AttributeComparison::IgnoreNamespace
+  ));
+  // Ignore both the namespace and the argument
+  static_assert(std::meta::has_attribute(
+    ^^DeprecatedFunction,
+    ^^[[gnu::deprecated]],
+    std::meta::AttributeComparison::IgnoreNamespace | std::meta::AttributeComparison::IgnoreArgument
+  ));
   return true;
 }
 


### PR DESCRIPTION
### has_attribute

```cpp

    namespace std::meta {
      enum AttributeComparison {
        ContributeNamespace,
        ContributeArgument,
      };

      consteval auto has_attribute(
        info                entity,
        info                attribute,
        AttributeComparison policy = AttributeComparison::ContributeNamespace | AttributeComparison::ContributeArgument) -> bool;
    }


```
