### PR TITLE
Dedup repeated attribute on decl

### DIFF
--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -1748,10 +1748,7 @@ bool DiagnoseReflectionKind(DiagFn Diagnoser, SourceRange Range,
 
 llvm::SmallVector<const Attr*, 8> static collectUniqueCxx11Attrs(const Decl *D) {
   llvm::SmallVector<const Attr*, 8> Result;
-  // We ll persist a representation of the attribute with the scope otherwise
-  // we would count [[clang::warn_unused_result]] and [[nodiscard]] as
-  // the same attribute
-  llvm::SmallSet<std::string, 8> SeenKinds; // FIXME why not use ParsedAttr->profile()
+  llvm::SmallSet<std::string, 8> SeenKinds;
 
   for (const Decl *RD : D->redecls()) {
     if (!RD->hasAttrs()) {
@@ -1761,10 +1758,8 @@ llvm::SmallVector<const Attr*, 8> static collectUniqueCxx11Attrs(const Decl *D) 
       if (!isAttributeWithReflectableVariant(A->getParsedKind())) {
         continue;
       }
-      std::string S;
-      llvm::raw_string_ostream OS(S);
-      A->printPretty(OS, D->getASTContext().getPrintingPolicy());
-      if (SeenKinds.insert(S).second) {
+
+      if (SeenKinds.insert(std::string(A->getSpelling())).second) {
         Result.push_back(A);
       }
     }
@@ -1889,7 +1884,7 @@ static const ParsedAttr* toSyntacticForm(const Attr* val, ASTContext * C) {
 }
 
 enum class AttributeComparison : int64_t {
-  Default         = 1 << 0,
+  /* 0 = include all */
   IgnoreNamespace = 1 << 1, // Namespace is ignored during the comparison
   IgnoreArgument  = 1 << 2, // The argument is ignored during the comparison
 };

--- a/libcxx/include/experimental/meta
+++ b/libcxx/include/experimental/meta
@@ -2230,15 +2230,24 @@ consteval auto is_attribute(info r) -> bool {
 }
 
 
-enum class AttributeComparison : int64_t {
-  Default         = 1 << 0,
-  IgnoreNamespace = 1 << 1, // Namespace is ignored during the comparison
-  IgnoreArgument  = 1 << 2, // The argument is ignored during the comparison
+enum class attribute_comparison : int64_t {
+  /* 0 is default constructed */
+  ignore_namespace = 1 << 1, // Namespace is ignored during the comparison
+  ignore_argument  = 1 << 2, // The argument is ignored during the comparison
 };
 
-constexpr AttributeComparison operator|(AttributeComparison a, AttributeComparison b) noexcept {
-  return static_cast<AttributeComparison>(
+constexpr attribute_comparison operator|(attribute_comparison a, attribute_comparison b) noexcept {
+  return static_cast<attribute_comparison>(
     static_cast<int64_t>(a) | static_cast<int64_t>(b));
+}
+
+// Return true if the given 'entity' has the given 'attribute' appertained
+// to it
+consteval auto has_attribute(
+  info entity,
+  info attribute
+) -> bool {
+  return __metafunction(detail::__metafn_has_attribute, entity, attribute, attribute_comparison{});
 }
 
 // Return true if the given 'entity' has the given 'attribute' appertained
@@ -2246,7 +2255,7 @@ constexpr AttributeComparison operator|(AttributeComparison a, AttributeComparis
 consteval auto has_attribute(
   info entity,
   info attribute,
-  AttributeComparison policy = AttributeComparison::Default
+  attribute_comparison policy
 ) -> bool {
   return __metafunction(detail::__metafn_has_attribute, entity, attribute, policy);
 }

--- a/libcxx/test/std/experimental/reflection/p3385-attributes.pass.cpp
+++ b/libcxx/test/std/experimental/reflection/p3385-attributes.pass.cpp
@@ -72,6 +72,15 @@ consteval bool testIdentifierOf() {
   return true;
 }
 
+enum class TMD;
+enum class [[nodiscard("Error discarded")]] TMD;
+enum class [[nodiscard]] TMD {};
+consteval bool testMultipleDecl() {
+  // Either of [[nodiscard("Error discarded")]] or [[nodiscard]]
+  static_assert(attributes_of(^^TMD).size() == 1);
+  return true;
+}
+
 consteval bool testHasAttr() {
   static_assert(
        std::meta::has_attribute(^^Foo, stdAttr)


### PR DESCRIPTION
```cpp
enum class TMD;
enum class [[nodiscard("Error discarded")]] TMD;
enum class [[nodiscard]] TMD {};
consteval bool testMultipleDecl() {
  // Either of [[nodiscard("Error discarded")]] or [[nodiscard]]
  static_assert(attributes_of(^^TMD).size() == 1);
  return true;
}
```